### PR TITLE
Changes to repmgr cookbook for CentOS

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -131,7 +131,7 @@ else
 
   if(master_node)
     node.default[:repmgr][:addressing][:master] = master_node[:ipaddress]
-    file '/var/lib/postgresql/.ssh/known_hosts' do
+    file "#{node[:repmgr][:pg_home]}/.ssh/known_hosts" do
       content %x{ssh-keyscan #{node[:repmgr][:addressing][:master]}}
     end
   end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -8,7 +8,7 @@ if(node[:repmgr][:replication][:role] == 'master')
       raise 'Different node is already identified as PostgreSQL master!'
     end
     only_if do
-      output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show'}
+      output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show 2> /dev/null'}
       master = output.split("\n").detect{|s| s.include?('master')}
       !master.to_s.empty? && !master.to_s.include?(node[:repmgr][:addressing][:self])
     end
@@ -18,7 +18,7 @@ if(node[:repmgr][:replication][:role] == 'master')
     command "repmgr -f #{node[:repmgr][:config_file_path]} master register"
     user 'postgres'
     not_if do
-      output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show'}
+      output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show 2> /dev/null'}
       master = output.split("\n").detect{|s| s.include?('master')}
       master.to_s.include?(node[:repmgr][:addressing][:self])
     end
@@ -35,13 +35,13 @@ else
     # build our command in a string because it's long
     node.default[:repmgr][:addressing][:master] = master_node[:ipaddress]
     clone_cmd = "#{node[:repmgr][:repmgr_bin]} " << 
-      "-D #{node[:postgresql][:config][:data_directory]} " <<
+      "--force -D #{node[:postgresql][:config][:data_directory]} " <<
       "-p #{node[:postgresql][:config][:port]} -U #{node[:repmgr][:replication][:user]} " <<
       "-R #{node[:repmgr][:system_user]} -d #{node[:repmgr][:replication][:database]} " <<
       "standby clone #{node[:repmgr][:addressing][:master]}"
 
     service 'postgresql-repmgr-stopper' do
-      service_name 'postgresql'
+      service_name node['postgresql']['server']['service_name']
       action :stop
     end
 
@@ -50,22 +50,13 @@ else
       only_if "kill -0 `cat #{node[:postgresql][:config][:external_pid_file]}`"
     end
 
-    directory 'scrub postgresql data directory' do
-      action :delete
-      recursive true
-      path node[:postgresql][:config][:data_directory]
-      only_if do
-        File.directory?(node[:postgresql][:config][:data_directory])
-      end
-    end
-
     execute 'clone standby' do
       user 'postgres'
       command clone_cmd
     end
     
     service 'postgresql-repmgr-starter' do
-      service_name 'postgresql'
+      service_name node['postgresql']['server']['service_name']
       action :start
     end
 

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -8,7 +8,7 @@ if(node[:repmgr][:replication][:role] == 'master')
       raise 'Different node is already identified as PostgreSQL master!'
     end
     only_if do
-      output = %x{sudo -u postgres repmgr -f #{node[:repmgr][:config_file_path]} cluster show}
+      output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show'}
       master = output.split("\n").detect{|s| s.include?('master')}
       !master.to_s.empty? && !master.to_s.include?(node[:repmgr][:addressing][:self])
     end
@@ -18,7 +18,7 @@ if(node[:repmgr][:replication][:role] == 'master')
     command "repmgr -f #{node[:repmgr][:config_file_path]} master register"
     user 'postgres'
     not_if do
-      output = %x{sudo -u postgres repmgr -f #{node[:repmgr][:config_file_path]} cluster show}
+      output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show'}
       master = output.split("\n").detect{|s| s.include?('master')}
       master.to_s.include?(node[:repmgr][:addressing][:self])
     end

--- a/recipes/smart_repmgr_id.rb
+++ b/recipes/smart_repmgr_id.rb
@@ -1,7 +1,7 @@
 include_recipe 'postgresql::ruby'
 
 proper_id_aquired = lambda do
-  output = %x{sudo -u postgres repmgr -f #{node[:repmgr][:config_file_path]} cluster show}
+  output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show'}
   !!output.split("\n").detect do |n| 
     n.include?(node[:ipaddress]) || n.include?(node[:repmgr][:addressing][:self])
   end
@@ -12,7 +12,7 @@ ruby_block 'Confirm repmgr ID for node' do
     tries = 0
     until(proper_id_aquired.call || tries >= node[:repmgr][:id_attempts])
       Chef::Log.info "Attempting to aquire proper repmgr ID for node! (note: this may require multiple attempts)"
-      cur_max = %x{sudo -u postgres psql -t -A -d #{node[:repmgr][:replication][:database]} -c 'select id from repmgr_#{node[:repmgr][:cluster_name]}.repl_nodes order by id desc limit 1'}.strip.to_i
+      cur_max = %x{su postgres -s'psql -t -A -d #{node[:repmgr][:replication][:database]}' -c 'select id from repmgr_#{node[:repmgr][:cluster_name]}.repl_nodes order by id desc limit 1'}.strip.to_i
       node.set[:repmgr][:repmgr_node_id] = cur_max + 1
       t = Chef::Resource::Template.new(node[:repmgr][:config_file_path], run_context)
       t.source 'repmgr.conf.erb'

--- a/recipes/smart_repmgr_id.rb
+++ b/recipes/smart_repmgr_id.rb
@@ -1,7 +1,7 @@
 include_recipe 'postgresql::ruby'
 
 proper_id_aquired = lambda do
-  output = %x{su postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show'}
+  output = %x{su - postgres -c'repmgr -f #{node[:repmgr][:config_file_path]} cluster show'}
   !!output.split("\n").detect do |n| 
     n.include?(node[:ipaddress]) || n.include?(node[:repmgr][:addressing][:self])
   end
@@ -12,7 +12,9 @@ ruby_block 'Confirm repmgr ID for node' do
     tries = 0
     until(proper_id_aquired.call || tries >= node[:repmgr][:id_attempts])
       Chef::Log.info "Attempting to aquire proper repmgr ID for node! (note: this may require multiple attempts)"
-      cur_max = %x{su postgres -s'psql -t -A -d #{node[:repmgr][:replication][:database]}' -c 'select id from repmgr_#{node[:repmgr][:cluster_name]}.repl_nodes order by id desc limit 1'}.strip.to_i
+      sql_statement = "select id from repmgr_#{node[:repmgr][:cluster_name]}.repl_nodes order by id desc limit 1"
+      sql_command = "psql -t -A -d #{node[:repmgr][:replication][:database]}"
+      cur_max = %x{echo #{sql_statement} | su postgres -c'#{sql_command}'}.strip.to_i
       node.set[:repmgr][:repmgr_node_id] = cur_max + 1
       t = Chef::Resource::Template.new(node[:repmgr][:config_file_path], run_context)
       t.source 'repmgr.conf.erb'

--- a/templates/default/repmgr.conf.erb
+++ b/templates/default/repmgr.conf.erb
@@ -1,3 +1,3 @@
 cluster=<%= node[:repmgr][:cluster_name] %>
 node=<%= node[:repmgr][:repmgr_node_id] %>
-conninfo='host=<%= node.ipaddress %> user=<%= node[:repmgr][:replication][:user] %> dbname=<%= node[:repmgr][:replication][:database] %>'
+conninfo='host=<%= node.ipaddress %> user=<%= node[:repmgr][:replication][:user] %> dbname=<%= node[:repmgr][:replication][:database] %> password=<%= node[:repmgr][:replication][:user_password] %>'

--- a/templates/default/repmgrd.initd.erb
+++ b/templates/default/repmgrd.initd.erb
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Author: Chris Roberts (<chris@hw-ops.com>)
 #
@@ -13,23 +14,41 @@ source /etc/rc.d/init.d/functions
 
 [ -x <%= @bin_path %> ] || exit 1
 
+start() {
+  echo -n "Starting repmgrd"
+  <% if @el -%>
+  daemon "<%= @bin_path %> -f /etc/repmgr/repmgr.conf &"
+  sleep 2
+  <% else -%>
+  start-stop-daemon --start --quiet --chuid postgres --background --exec <%= @bin_path %> -- -f /etc/repmgr/repmgr.conf
+  <% end -%>
+  echo
+}
+
+stop() {
+  echo "Stopping repmgrd"
+  kill -SIGTERM `pgrep <%= File.basename(@bin_path) %>` &> /dev/null
+}
+
+status() {
+  kill -0 `pgrep <%= File.basename(@bin_path) %>` &> /dev/null \
+    && echo 'Running' && return 0\
+    || echo 'Stopped' && return 3
+}
+
 case "$1" in
   start)
-    echo -n "Starting repmgrd"
-    <% if @el -%>
-    daemon <%= @bin_path %> -f /etc/repmgr/repmgr.conf &
-    <% else -%>
-    start-stop-daemon --start --quiet --chuid postgres --background --exec <%= @bin_path %> -- -f /etc/repmgr/repmgr.conf
-    <% end -%>
-    echo
+    start
+    status &> /dev/null
+    exit $?
     ;;
   stop)
-    echo "Stopping repmgrd"
-    kill -SIGTERM `pgrep <%= File.basename(@bin_path) %>` &> /dev/null
+    stop
+    status &> /dev/null
+    exit [ $? == 3 ]
     ;;
   status)
-    kill -0 `pgrep <%= File.basename(@bin_path) %>` &> /dev/null
-    $? && echo 'Running' || echo 'Stopped'
+    status
     ;;
   *)
     echo "Usage: $0 {start|stop|status}"

--- a/templates/default/repmgrd.initd.erb
+++ b/templates/default/repmgrd.initd.erb
@@ -15,19 +15,21 @@ source /etc/rc.d/init.d/functions
 
 case "$1" in
   start)
-    echo "Starting repmgrd"
+    echo -n "Starting repmgrd"
     <% if @el -%>
-    daemon <%= @bin_path %>
+    daemon <%= @bin_path %> -f /etc/repmgr/repmgr.conf &
     <% else -%>
     start-stop-daemon --start --quiet --chuid postgres --background --exec <%= @bin_path %> -- -f /etc/repmgr/repmgr.conf
     <% end -%>
+    echo
     ;;
   stop)
     echo "Stopping repmgrd"
-    kill -SIGHUP `pgrep <%= @bin_path %>` &> /dev/null
+    kill -SIGTERM `pgrep <%= File.basename(@bin_path) %>` &> /dev/null
     ;;
   status)
-    kill -0 `pgrep <%= @bin_path %>` &> /dev/null
+    kill -0 `pgrep <%= File.basename(@bin_path) %>` &> /dev/null
+    $? && echo 'Running' || echo 'Stopped'
     ;;
   *)
     echo "Usage: $0 {start|stop|status}"


### PR DESCRIPTION
These changes were necessary to getting repmgr working with Postgres 9.2 on CentOS. The most salient is a small rewrite of the initd script, and replacement of the wholesale wipe of the data directory with the `--force` flag to repmgr clone.
