### PR TITLE
Update recipe inclusion to be more compatible

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,5 +1,5 @@
 require 'securerandom'
-include_recipe 'database'
+include_recipe 'database::postgresql'
 include_recipe 'repmgr::dumb_repmgr_id'
 
 # create rep user and rep db


### PR DESCRIPTION
The database cookbook has removed the default recipe in the 3.0+ series of releases. This quick change makes it more compatible with current and previous versions.
